### PR TITLE
Potential fix for code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/birthday_paradox/birthday_paradox.html
+++ b/birthday_paradox/birthday_paradox.html
@@ -115,7 +115,7 @@
           kalkulacija =
             results.instance.exports.numericki_izracun_rodendanskog_paradoksa;
           document.getElementById("tipka").onclick = () => {
-            document.getElementById("rezultat").innerHTML = `
+            document.getElementById("rezultat").textContent = `
       Birthday(${document.getElementById("broj_dana_u_godini").value},
                ${document.getElementById("broj_ljudi").value},
                ${document.getElementById("broj_kolizija").value}) =


### PR DESCRIPTION
Potential fix for [https://github.com/FlatAssembler/AECforWebAssembly/security/code-scanning/4](https://github.com/FlatAssembler/AECforWebAssembly/security/code-scanning/4)

Use `textContent` instead of `innerHTML` for rendering the result string. This preserves existing displayed text behavior (including line breaks/spacing from the template literal) while ensuring interpolated input values are treated as plain text, not HTML.

In `birthday_paradox/birthday_paradox.html`, update the click handler assignment block at the current `document.getElementById("rezultat").innerHTML = ...` location (around lines 118–130). Replace only that sink with `textContent`. No new imports, helpers, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
